### PR TITLE
fix: cleanup and add pledged total endpoint

### DIFF
--- a/pages/api/pledged/history.ts
+++ b/pages/api/pledged/history.ts
@@ -50,7 +50,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     res.json({
       success: true,
       statusCode: 200,
-      entries: data.body.list,
+      results: data.body.list,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/pages/api/pledged/index.ts
+++ b/pages/api/pledged/index.ts
@@ -29,9 +29,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     data.body.list.shift();
 
     // get the total amount contributed to date...
-    const result = data.body.list.reduce((total, row) => {
-      return total + row.contributeVolume;
-    }, 0);
+    const result = {
+      total: data.body.list.reduce((total, row) => {
+        return total + row.contributeVolume;
+      }, 0),
+      history: data.body.list
+    };
 
     // set up response...
     res.setHeader("Access-Control-Allow-Origin", "*");
@@ -53,7 +56,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     res.json({
       success: true,
       statusCode: 200,
-      total: result,
+      result: result,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/pages/api/pledged/total.ts
+++ b/pages/api/pledged/total.ts
@@ -1,0 +1,71 @@
+import {
+    NextApiRequest,
+    NextApiResponse
+  } from "next";
+  import { getAnalyticsDataRecursivelyFrom } from "@/services/analytics";
+  
+  // - Constants
+  const CACHE_TIME = 1800;
+  
+  // Main handler to construct response
+  const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+      // get now as unix ts
+      const timestamp = new Date().getTime() / 1000;
+  
+      // fetch all data (from cache if available)
+      const data = await getAnalyticsDataRecursivelyFrom(timestamp);
+      
+      // no data then 500
+      if (!data) {
+        return res.json({
+          success: false,
+          statusCode: 500,
+          message: "no-data-found",
+        });
+      }
+  
+      // first result in the raw csv file is always incomplete...
+      data.body.list.shift();
+  
+      // get the total amount contributed to date...
+      const result = data.body.list.reduce((total, row) => {
+        return total + row.contributeVolume;
+      }, 0);
+  
+      // set up response...
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader(
+        "Access-Control-Allow-Headers",
+        "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+      );
+      if (req.method == "OPTIONS") {
+        res.setHeader(
+          "Access-Control-Allow-Methods",
+          "PUT, POST, PATCH, DELETE, GET"
+        );
+        return res.status(200).json({});
+      }
+      res.setHeader(
+        "Cache-Control",
+        `s-maxage=${CACHE_TIME}, stale-while-revalidate=${2 * CACHE_TIME}`
+      );
+      res.json({
+        success: true,
+        statusCode: 200,
+        result: result,
+      });
+  
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      res
+        .status(500)
+        .json({
+          success: false,
+          statusCode: 500,
+          message: error?.message
+        });
+    }
+  };
+  
+  export default handler;


### PR DESCRIPTION
Refactors the api to look like this:

Expose all historic pledge entries from the `chart-100-day.json` file:

```js
await (await fetch('http://localhost:3000/api/pledged/history')).json()

# returns:

{
    "success": true,
    "statusCode": 200,
    "results": [
        {
            "date": "2023-01-16",
            "ethPrice": 1553.93,
            "bitPrice": 0.536834,
            "tradeVolume": 12837491501,
            "contributeVolume": 3209373,
            "ethAmount": 0,
            "ethCount": 0,
            "usdtAmount": 0,
            "usdtCount": 0,
            "usdcAmount": 0,
            "usdcCount": 0,
            "bitAmount": 3209372.88,
            "bitCount": 5978334.4669
        },
        ...
    ]
}
```

Expose the total amount (usd) pledged:

```js
await (await fetch('http://localhost:3000/api/pledged/total')).json()

# returns:

{
    "success": true,
    "statusCode": 200,
    "result": 1285690185.060001
}

```

Expose all data about pledges:

```js
await (await fetch('http://localhost:3000/api/pledged')).json()

# returns:

{
    "success": true,
    "statusCode": 200,
    "result": {
        "total": 1285690185.060001,
        "history": [ ... ]
    }
}

```